### PR TITLE
Productionize Squisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /target
 
-# Ignore any glb files created in tests
-*.glb
+# Ignore all outputs created in tests
+/test_output
 
 # Ignore any assets created during testing
 *.jpg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +206,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +384,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "image"
 version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +542,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -736,6 +770,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
 name = "rustix"
 version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,10 +873,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "env_logger",
  "fs-err",
  "gltf",
  "image 0.24.3",
  "ktx2",
+ "log",
  "seahash",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,10 +57,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "color_quant"
@@ -146,6 +189,27 @@ name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "exr"
@@ -265,6 +329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +342,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "image"
@@ -322,6 +398,28 @@ name = "inflections"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itoa"
@@ -376,9 +474,15 @@ checksum = "7efd1d698db0759e6ef11a7cd44407407399a910c774dd804c64c032da7826ff"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -493,7 +597,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -502,6 +606,12 @@ name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "pin-project"
@@ -548,10 +658,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.40"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -587,6 +721,20 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -660,11 +808,18 @@ dependencies = [
 name = "squisher"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "gltf",
  "image 0.24.3",
  "ktx2",
  "seahash",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -675,6 +830,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -702,6 +866,12 @@ name = "unicode-ident"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -768,3 +938,100 @@ name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "anyhow"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +255,12 @@ dependencies = [
  "pin-project",
  "spin",
 ]
+
+[[package]]
+name = "fs-err"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
 
 [[package]]
 name = "futures-core"
@@ -808,7 +820,9 @@ dependencies = [
 name = "squisher"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
+ "fs-err",
  "gltf",
  "image 0.24.3",
  "ktx2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "squisher"
+description = "Creates optimised, platform specific glTF files"
+authors = ["Let Eyes Equals Two"]
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.1.6", features = ["derive"] }
 gltf = { version = "1.0", features = ["KHR_lights_punctual"] }
 image = "0.24"
 seahash = "4.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-edition = "2021"
 name = "squisher"
 version = "0.1.0"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gltf = {features = ["KHR_lights_punctual"], version = "1.0"}
+gltf = { version = "1.0", features = ["KHR_lights_punctual"] }
 image = "0.24"
 seahash = "4.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.69"
 clap = { version = "4.1.6", features = ["derive"] }
+fs-err = "2.9.0"
 gltf = { version = "1.0", features = ["KHR_lights_punctual"] }
 image = "0.24"
 seahash = "4.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.69"
 clap = { version = "4.1.6", features = ["derive"] }
+env_logger = "0.10.0"
 fs-err = "2.9.0"
 gltf = { version = "1.0", features = ["KHR_lights_punctual"] }
 image = "0.24"
+log = "0.4.17"
 seahash = "4.1.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Squisher
 
 ## What?
-`squisher` is a program that takes a glTF or .glb file with PNG/JPG textures and produces a .glb file where the textures have been replaced with ASTC compressed ktx2 files, *explicitly breaking the glTF spec*: [source](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#_image_mimetype).
+`squisher` is a program that takes a glTF or .glb file with PNG/JPG textures and produces a .glb file where the textures have been replaced with ASTC compressed KTX2 files, *explicitly breaking the glTF spec*: [source](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#_image_mimetype).
 
 If you want your assets to use optimised textures but don't want to pay the runtime transcoding cost of [KHR_texture_basisu](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_texture_basisu/README.md), this tool is for you.
 
@@ -17,16 +17,21 @@ cargo install --git https://github.com/leetvr/squisher.git
 
 Running `squisher` is easy:
 
-````bash
+```bash
 squisher your_file.glb output.glb
-````
+```
 
-Which will produce `output.glb`.
+Which will produce `output.glb`, containing ASTC compressed KTX2 textures.
+
+You can also use uncompressed RGBA8 textures:
+
+```bash
+squisher --format rgba8 your_file.glb output.glb
+```
 
 ## Requirements
 To compile `squisher`, you need:
 - [Rust](https://rustup.rs/) 1.67.1 or newer
 
-To run `squisher` you must have the following programs available on your system PATH:
-- [ARM astc-encoder](https://github.com/ARM-software/astc-encoder) 4.0.0 or newer
+To run `squisher` you must have the following available on your system PATH:
 - [Khronos Texture Tools](https://github.khronos.org/KTX-Software/ktxtools) 4.1.0 or newer

--- a/README.md
+++ b/README.md
@@ -9,24 +9,24 @@ If you want your assets to use optimised textures but don't want to pay the runt
 Because [hotham](https://github.com/leetvr/hotham) works best with compressed textures, and doing this stuff by hand is time consuming. It takes *literal minutes*. And we all know that [a watched pot never boils](https://www.youtube.com/watch?v=eTFBxp0VW9M).
 
 ## How?
+Install `squisher` with `cargo install`:
+
+```bash
+cargo install --git https://github.com/leetvr/squisher.git
+```
+
 Running `squisher` is easy:
 
 ````bash
-cargo run your_file.gltf
+squisher your_file.glb output.glb
 ````
 
-OR
-
-````bash
-cargo run your_file.glb
-````
-
-Which will produce `your_file_squished.glb`.
+Which will produce `output.glb`.
 
 ## Requirements
- > note: this part is currently a lie, paths to these tools is hardcoded
- 
-In addition to [Rust](https://rustup.rs/), you must have the following programs installed. Tell `squisher` where they are by setting the environment variables `ASTC_PATH` and `KTX2KTK2_PATH` respectively:
+To compile `squisher`, you need:
+- [Rust](https://rustup.rs/) 1.67.1 or newer
 
-- arm's [astc-encoder](https://github.com/ARM-software/astc-encoder)
-- Khronos' [ktx2ktxt2](https://github.khronos.org/KTX-Software/ktxtools/ktx2ktx2.html)
+To run `squisher` you must have the following programs available on your system PATH:
+- [ARM astc-encoder](https://github.com/ARM-software/astc-encoder) 4.0.0 or newer
+- [Khronos Texture Tools](https://github.khronos.org/KTX-Software/ktxtools) 4.1.0 or newer

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ struct Args {
     /// Where to output the squished output.
     output: PathBuf,
 
-    /// What texture format to use. Can be 'raw' or 'astc'.
-    #[clap(long)]
+    /// What texture format to use. Can be 'astc' (default) or 'rgba8'.
+    #[clap(long, default_value = "astc")]
     format: TextureFormat,
 
     /// Enables more verbose logging.
@@ -49,7 +49,7 @@ impl FromStr for TextureFormat {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "raw" => Ok(Self::Rgba8),
+            "rgba8" => Ok(Self::Rgba8),
             "astc" => Ok(Self::Astc),
             _ => bail!("unknown texture format '{s}', expected 'rgba8' or 'astc'"),
         }
@@ -188,7 +188,10 @@ impl SquishContext {
         texture: &gltf::Texture,
         texture_type: TextureType,
     ) -> anyhow::Result<Vec<u8>> {
-        log::info!("Compressing {texture_type:?}...");
+        log::info!(
+            "Compressing {texture_type:?} as format {:?}...",
+            self.texture_format
+        );
 
         // Okay. First thing we need to do is get the path of the texture. If the source is *inside* the GLB, we'll have to write it to disk first.
         let (input_path, _original_size) = match texture.source().source() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 use std::{
     borrow::Cow,
     collections::HashMap,
+    hash::Hasher,
     io,
     path::{Path, PathBuf},
     process::Command,
+    str::FromStr,
 };
 
 use anyhow::{bail, Context, Error};
@@ -14,9 +16,6 @@ const MAX_SIZE: u32 = 4096;
 
 static BIN_TOKTX: &str = "toktx";
 
-/// Check for cached versions. Mark this as false if the compression algorithm changes in some way.
-const USE_CACHE: bool = true;
-
 #[derive(Parser)]
 #[command(author, version, about)]
 struct Args {
@@ -26,38 +25,50 @@ struct Args {
     /// Where to output the squished output.
     output: PathBuf,
 
+    /// What texture format to use. Can be 'raw' or 'astc'.
+    #[clap(long)]
+    format: TextureFormat,
+
     /// Enables more verbose logging.
     #[clap(short, long)]
     verbose: bool,
+
+    /// Disable the image cache, forcing all images to be reprocessed.
+    #[clap(long)]
+    no_cache: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum TextureFormat {
+    Rgba8,
+    Astc,
+}
+
+impl FromStr for TextureFormat {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "raw" => Ok(Self::Rgba8),
+            "astc" => Ok(Self::Astc),
+            _ => bail!("unknown texture format '{s}', expected 'rgba8' or 'astc'"),
+        }
+    }
 }
 
 fn main() {
     let args = Args::parse();
 
-    if let Err(err) = run(args) {
+    if let Err(err) = squish(args) {
         log::error!("Fatal error: {err:?}");
         std::process::exit(1);
     }
 }
 
-fn run(args: Args) -> anyhow::Result<()> {
-    configure_logging(args.verbose);
-    squish(&args.input, &args.output)?;
-    Ok(())
-}
-
-fn configure_logging(verbose: bool) {
-    let filter = if verbose {
-        "squisher=debug,warn"
-    } else {
-        "squisher=info,warn"
-    };
-
-    let log_env = env_logger::Env::default().default_filter_or(filter);
-
-    env_logger::Builder::from_env(log_env)
-        .format_timestamp(None)
-        .init();
+struct SquishContext {
+    input: Input,
+    use_cache: bool,
+    texture_format: TextureFormat,
 }
 
 struct Input {
@@ -89,181 +100,284 @@ impl TextureType {
     }
 }
 
-pub fn squish<P: AsRef<Path>>(input_path: P, output_path: P) -> anyhow::Result<()> {
-    let input_path = input_path.as_ref();
-    let output_path = output_path.as_ref();
+fn squish(args: Args) -> anyhow::Result<()> {
+    configure_logging(args.verbose);
 
-    log::info!("Squishing {}", input_path.display());
-    let input = open(input_path)?;
-    let optimized_glb = optimize(input)?;
+    let use_cache = !args.no_cache;
 
-    fs_err::write(output_path, optimized_glb)?;
+    log::info!("Squishing {}", args.input.display());
+    let input = open(&args.input)?;
+    let context = SquishContext {
+        input,
+        use_cache,
+        texture_format: args.format,
+    };
 
-    log::info!("Squished file: {}! ✨ Enjoy ✨", output_path.display());
+    let optimized_glb = context.optimize()?;
+    fs_err::write(&args.output, optimized_glb)?;
+
+    log::info!("Squished file: {}! ✨ Enjoy ✨", args.output.display());
     Ok(())
 }
 
-fn optimize(input: Input) -> anyhow::Result<Vec<u8>> {
-    let mut image_map: HashMap<usize, Vec<u8>> = Default::default();
-
-    // First, compress the images.
-    // In order to do this, we need to have a bit of information about them first:
-    let document = &input.document;
-    for material in document.materials() {
-        // Okiedokie. Each part of the material needs to be treated differently. Let's start with the easy stuff.
-        let pbr = material.pbr_metallic_roughness();
-        if let Some(base_colour) = pbr.base_color_texture() {
-            let texture = base_colour.texture();
-            let compressed = compress_texture(&texture, &input, TextureType::BaseColor)?;
-            image_map.insert(texture.source().index(), compressed);
-        }
-
-        if let Some(metallic_roughness) = pbr.metallic_roughness_texture() {
-            let texture = metallic_roughness.texture();
-            let compressed =
-                compress_texture(&texture, &input, TextureType::MetallicRoughnessOcclusion)?;
-            image_map.insert(texture.source().index(), compressed);
-        }
-
-        if let Some(normal) = material.normal_texture() {
-            let texture = normal.texture();
-            let compressed = compress_texture(&texture, &input, TextureType::Normal)?;
-            image_map.insert(texture.source().index(), compressed);
-        }
-
-        if let Some(emissive) = material.emissive_texture() {
-            let texture = emissive.texture();
-            let compressed = compress_texture(&texture, &input, TextureType::Emissive)?;
-            image_map.insert(texture.source().index(), compressed);
-        }
-
-        if let Some(occlusion) = material.occlusion_texture() {
-            let texture = occlusion.texture();
-            let compressed =
-                compress_texture(&texture, &input, TextureType::MetallicRoughnessOcclusion)?;
-            image_map.insert(texture.source().index(), compressed);
-        }
-    }
-
-    // Okay. Now that's done we need a new GLB file.
-    create_glb_file(input, image_map)
-}
-
-fn create_glb_file(input: Input, image_map: HashMap<usize, Vec<u8>>) -> anyhow::Result<Vec<u8>> {
-    // Ugh, this is going to be disgusting.
-    let mut new_blob: Vec<u8> = Vec::new();
-    let blob = &input.blob;
-    let mut new_buffer_views: Vec<gltf::json::buffer::View> = Vec::new();
-    let mut new_root = input.document.into_json();
-
-    // First, we need to make a map that lets us find which image a bufferView points to, if any.
-    let mut image_buffer_view_indices = HashMap::new();
-    for (index, image) in new_root.images.iter().enumerate() {
-        if let Some(image_view_index) = image.buffer_view {
-            image_buffer_view_indices.insert(image_view_index.value(), index);
-        }
-    }
-
-    // Next, go through each buffer view and write its data into our blob.
-    for (index, view) in new_root.buffer_views.iter_mut().enumerate() {
-        // Stash the CURRENT length (eg before we add to it) of the new blob
-        let new_offset = new_blob.len();
-
-        // Okay, this buffer view points to an image - we instead want to grab the bytes of the compressed image.
-        let bytes = if let Some(image_index) = image_buffer_view_indices.get(&index) {
-            image_map.get(image_index).unwrap()
-        } else {
-            // Not an image - just get the original data and return it as-is.
-            let start = view.byte_offset.unwrap_or_default() as usize;
-            let end = start + view.byte_length as usize;
-            &blob[start..end]
-        };
-
-        // And write it into the new blob.
-        new_blob.extend_from_slice(bytes);
-
-        // Now create a new view and change its offset to reflect the new blob.
-        let mut new_view = view.clone();
-        new_view.byte_offset = Some(new_offset as _);
-        new_view.byte_length = bytes.len() as _;
-        new_buffer_views.push(new_view);
-    }
-
-    // OK. Now we need to update any images that had their uri set (bufferView and uri are mutually exclusive)
-    for (index, image) in new_root.images.iter_mut().enumerate() {
-        // Set the MIME type
-        image.mime_type = Some(MimeType("image/ktx2".to_string()));
-
-        // This image has already been processed, we can move on.
-        if image.uri.is_none() {
-            continue;
-        }
-
-        // Right. As before, stash the current length of the new blob
-        let new_offset = new_blob.len();
-
-        // Clear the URI
-        image.uri = None;
-
-        // Get the current length of the buffer views to use as an index
-        let buffer_view_index = new_buffer_views.len();
-
-        // Now write the new image data into the blob
-        let image_data = image_map.get(&index).unwrap();
-        new_blob.extend(image_data);
-
-        // Create a new buffer view for this image
-        let view = gltf::json::buffer::View {
-            buffer: Index::new(0 as _),
-            byte_length: image_data.len() as _,
-            byte_offset: Some(new_offset as _),
-            byte_stride: None,
-            name: None,
-            target: None,
-            extensions: None,
-            extras: Default::default(),
-        };
-
-        // And add it to the list
-        new_buffer_views.push(view);
-
-        // Finally, update the image to point to this new view.
-        image.buffer_view = Some(Index::new(buffer_view_index as _));
-    }
-
-    // OK! We're done. Set the new root to use the new buffer views..
-    new_root.buffer_views = new_buffer_views;
-
-    // And make sure the buffer is set correctly.
-    new_root.buffers = vec![gltf::json::Buffer {
-        byte_length: new_blob.len() as _,
-        name: None,
-        uri: None,
-        extensions: None,
-        extras: Default::default(),
-    }];
-
-    // and.. that's it? Maybe? Hopefully.
-    // This part is mostly lifted from https://github.com/gltf-rs/gltf/blob/master/examples/export/main.rs
-
-    pad_byte_vector(&mut new_blob);
-    let buffer_length = new_blob.len() as u32;
-    let json_string = gltf::json::serialize::to_string(&new_root)?;
-    let mut json_offset = json_string.len() as u32;
-    align_to_multiple_of_four(&mut json_offset);
-
-    let glb = gltf::binary::Glb {
-        header: gltf::binary::Header {
-            magic: *b"glTF",
-            version: 2,
-            length: json_offset + buffer_length,
-        },
-        bin: Some(Cow::Owned(new_blob)),
-        json: Cow::Owned(json_string.into_bytes()),
+fn configure_logging(verbose: bool) {
+    let filter = if verbose {
+        "squisher=debug,warn"
+    } else {
+        "squisher=info,warn"
     };
 
-    // And we're done! Write the entire file to GLB.
-    Ok(glb.to_vec()?)
+    let log_env = env_logger::Env::default().default_filter_or(filter);
+
+    // If logging is already configured (like running in a test), we should
+    // suppress any issues initializing it.
+    let _ = env_logger::Builder::from_env(log_env)
+        .format_timestamp(None)
+        .try_init();
+}
+
+impl SquishContext {
+    fn optimize(self) -> anyhow::Result<Vec<u8>> {
+        let mut image_map: HashMap<usize, Vec<u8>> = Default::default();
+
+        // First, compress the images.
+        // In order to do this, we need to have a bit of information about them first:
+        let document = &self.input.document;
+        for material in document.materials() {
+            // Okiedokie. Each part of the material needs to be treated differently. Let's start with the easy stuff.
+            let pbr = material.pbr_metallic_roughness();
+            if let Some(base_colour) = pbr.base_color_texture() {
+                let texture = base_colour.texture();
+                let compressed = self.compress_texture(&texture, TextureType::BaseColor)?;
+                image_map.insert(texture.source().index(), compressed);
+            }
+
+            if let Some(metallic_roughness) = pbr.metallic_roughness_texture() {
+                let texture = metallic_roughness.texture();
+                let compressed =
+                    self.compress_texture(&texture, TextureType::MetallicRoughnessOcclusion)?;
+                image_map.insert(texture.source().index(), compressed);
+            }
+
+            if let Some(normal) = material.normal_texture() {
+                let texture = normal.texture();
+                let compressed = self.compress_texture(&texture, TextureType::Normal)?;
+                image_map.insert(texture.source().index(), compressed);
+            }
+
+            if let Some(emissive) = material.emissive_texture() {
+                let texture = emissive.texture();
+                let compressed = self.compress_texture(&texture, TextureType::Emissive)?;
+                image_map.insert(texture.source().index(), compressed);
+            }
+
+            if let Some(occlusion) = material.occlusion_texture() {
+                let texture = occlusion.texture();
+                let compressed =
+                    self.compress_texture(&texture, TextureType::MetallicRoughnessOcclusion)?;
+                image_map.insert(texture.source().index(), compressed);
+            }
+        }
+
+        // Okay. Now that's done we need a new GLB file.
+        self.create_glb_file(image_map)
+    }
+
+    fn compress_texture(
+        &self,
+        texture: &gltf::Texture,
+        texture_type: TextureType,
+    ) -> anyhow::Result<Vec<u8>> {
+        log::info!("Compressing {texture_type:?}...");
+
+        // Okay. First thing we need to do is get the path of the texture. If the source is *inside* the GLB, we'll have to write it to disk first.
+        let (input_path, _original_size) = match texture.source().source() {
+            gltf::image::Source::View { view, mime_type } => {
+                // Right. Bytes are BYTES.
+                let bytes = &self.input.blob[view.offset()..view.offset() + view.length()];
+                let mut path = file_name(self.texture_format, bytes);
+                let (extension, format) = match mime_type {
+                    "image/jpeg" => ("jpg", image::ImageFormat::Jpeg),
+                    "image/png" => ("png", image::ImageFormat::Png),
+                    _ => bail!("unsupported image MIME Type {mime_type}"),
+                };
+
+                // Now that we've got said bytes, let's resize the image.
+                let mut image = image::io::Reader::new(io::Cursor::new(bytes));
+                image.set_format(format);
+                let mut image = image.decode()?;
+
+                // TODO: Configurable max size for images.
+                if image.height() > MAX_SIZE {
+                    log::warn!(
+                        "Image is too large! ({}x{}), resizing to {}x{}",
+                        image.height(),
+                        image.width(),
+                        MAX_SIZE,
+                        MAX_SIZE,
+                    );
+                    image = image.resize(MAX_SIZE, MAX_SIZE, image::imageops::Lanczos3);
+                }
+
+                path.set_extension(extension);
+
+                image.save_with_format(&path, format)?;
+
+                (path, bytes.len())
+            }
+            gltf::image::Source::Uri { uri, .. } => {
+                // Technically glTF supports images not stored on disk (eg. the interweb) so let's make sure it's a real path.
+                let path = Path::new(uri);
+                anyhow::ensure!(
+                    path.exists(),
+                    "Corrupted glTF file or unsupported URI path - {}",
+                    uri
+                );
+                let bytes = fs_err::read(path)?;
+                let destination = file_name(self.texture_format, &bytes);
+                fs_err::write(&destination, &bytes)?;
+                (destination, bytes.len())
+            }
+        };
+
+        let mut output_path = input_path.clone();
+        output_path.set_extension("ktx2");
+
+        // This file has already been hashed!
+        if self.use_cache && output_path.exists() {
+            log::info!("Returning pre-compressed file!");
+        } else {
+            compress_image(
+                &input_path,
+                &mut output_path,
+                self.texture_format,
+                texture_type,
+            )?;
+        }
+
+        // Now slurp up the image:
+        let file = fs_err::read(&output_path)?;
+        log::debug!("Tempfile is at {}", output_path.display());
+
+        Ok(file)
+    }
+
+    fn create_glb_file(self, image_map: HashMap<usize, Vec<u8>>) -> anyhow::Result<Vec<u8>> {
+        // Ugh, this is going to be disgusting.
+        let mut new_blob: Vec<u8> = Vec::new();
+        let blob = &self.input.blob;
+        let mut new_buffer_views: Vec<gltf::json::buffer::View> = Vec::new();
+        let mut new_root = self.input.document.into_json();
+
+        // First, we need to make a map that lets us find which image a bufferView points to, if any.
+        let mut image_buffer_view_indices = HashMap::new();
+        for (index, image) in new_root.images.iter().enumerate() {
+            if let Some(image_view_index) = image.buffer_view {
+                image_buffer_view_indices.insert(image_view_index.value(), index);
+            }
+        }
+
+        // Next, go through each buffer view and write its data into our blob.
+        for (index, view) in new_root.buffer_views.iter_mut().enumerate() {
+            // Stash the CURRENT length (eg before we add to it) of the new blob
+            let new_offset = new_blob.len();
+
+            // Okay, this buffer view points to an image - we instead want to grab the bytes of the compressed image.
+            let bytes = if let Some(image_index) = image_buffer_view_indices.get(&index) {
+                image_map.get(image_index).unwrap()
+            } else {
+                // Not an image - just get the original data and return it as-is.
+                let start = view.byte_offset.unwrap_or_default() as usize;
+                let end = start + view.byte_length as usize;
+                &blob[start..end]
+            };
+
+            // And write it into the new blob.
+            new_blob.extend_from_slice(bytes);
+
+            // Now create a new view and change its offset to reflect the new blob.
+            let mut new_view = view.clone();
+            new_view.byte_offset = Some(new_offset as _);
+            new_view.byte_length = bytes.len() as _;
+            new_buffer_views.push(new_view);
+        }
+
+        // OK. Now we need to update any images that had their uri set (bufferView and uri are mutually exclusive)
+        for (index, image) in new_root.images.iter_mut().enumerate() {
+            // Set the MIME type
+            image.mime_type = Some(MimeType("image/ktx2".to_string()));
+
+            // This image has already been processed, we can move on.
+            if image.uri.is_none() {
+                continue;
+            }
+
+            // Right. As before, stash the current length of the new blob
+            let new_offset = new_blob.len();
+
+            // Clear the URI
+            image.uri = None;
+
+            // Get the current length of the buffer views to use as an index
+            let buffer_view_index = new_buffer_views.len();
+
+            // Now write the new image data into the blob
+            let image_data = image_map.get(&index).unwrap();
+            new_blob.extend(image_data);
+
+            // Create a new buffer view for this image
+            let view = gltf::json::buffer::View {
+                buffer: Index::new(0 as _),
+                byte_length: image_data.len() as _,
+                byte_offset: Some(new_offset as _),
+                byte_stride: None,
+                name: None,
+                target: None,
+                extensions: None,
+                extras: Default::default(),
+            };
+
+            // And add it to the list
+            new_buffer_views.push(view);
+
+            // Finally, update the image to point to this new view.
+            image.buffer_view = Some(Index::new(buffer_view_index as _));
+        }
+
+        // OK! We're done. Set the new root to use the new buffer views..
+        new_root.buffer_views = new_buffer_views;
+
+        // And make sure the buffer is set correctly.
+        new_root.buffers = vec![gltf::json::Buffer {
+            byte_length: new_blob.len() as _,
+            name: None,
+            uri: None,
+            extensions: None,
+            extras: Default::default(),
+        }];
+
+        // and.. that's it? Maybe? Hopefully.
+        // This part is mostly lifted from https://github.com/gltf-rs/gltf/blob/master/examples/export/main.rs
+
+        pad_byte_vector(&mut new_blob);
+        let buffer_length = new_blob.len() as u32;
+        let json_string = gltf::json::serialize::to_string(&new_root)?;
+        let mut json_offset = json_string.len() as u32;
+        align_to_multiple_of_four(&mut json_offset);
+
+        let glb = gltf::binary::Glb {
+            header: gltf::binary::Header {
+                magic: *b"glTF",
+                version: 2,
+                length: json_offset + buffer_length,
+            },
+            bin: Some(Cow::Owned(new_blob)),
+            json: Cow::Owned(json_string.into_bytes()),
+        };
+
+        // And we're done! Write the entire file to GLB.
+        Ok(glb.to_vec()?)
+    }
 }
 
 fn align_to_multiple_of_four(n: &mut u32) {
@@ -277,83 +391,10 @@ fn pad_byte_vector(vec: &mut Vec<u8>) {
     }
 }
 
-fn compress_texture(
-    texture: &gltf::Texture,
-    input: &Input,
-    texture_type: TextureType,
-) -> anyhow::Result<Vec<u8>> {
-    log::info!("Compressing {texture_type:?}...");
-
-    // Okay. First thing we need to do is get the path of the texture. If the source is *inside* the GLB, we'll have to write it to disk first.
-    let (input_path, _original_size) = match texture.source().source() {
-        gltf::image::Source::View { view, mime_type } => {
-            // Right. Bytes are BYTES.
-            let bytes = &input.blob[view.offset()..view.offset() + view.length()];
-            let mut path = file_name(bytes);
-            let (extension, format) = match mime_type {
-                "image/jpeg" => ("jpg", image::ImageFormat::Jpeg),
-                "image/png" => ("png", image::ImageFormat::Png),
-                _ => bail!("unsupported image MIME Type {mime_type}"),
-            };
-
-            // Now that we've got said bytes, let's resize the image.
-            let mut image = image::io::Reader::new(io::Cursor::new(bytes));
-            image.set_format(format);
-            let mut image = image.decode()?;
-
-            // TODO: Configurable max size for images.
-            if image.height() > MAX_SIZE {
-                log::warn!(
-                    "Image is too large! ({}x{}), resizing to {}x{}",
-                    image.height(),
-                    image.width(),
-                    MAX_SIZE,
-                    MAX_SIZE,
-                );
-                image = image.resize(MAX_SIZE, MAX_SIZE, image::imageops::Lanczos3);
-            }
-
-            path.set_extension(extension);
-
-            image.save_with_format(&path, format)?;
-
-            (path, bytes.len())
-        }
-        gltf::image::Source::Uri { uri, .. } => {
-            // Technically glTF supports images not stored on disk (eg. the interweb) so let's make sure it's a real path.
-            let path = Path::new(uri);
-            anyhow::ensure!(
-                path.exists(),
-                "Corrupted glTF file or unsupported URI path - {}",
-                uri
-            );
-            let file = fs_err::read(path)?;
-            let destination = file_name(&file);
-            fs_err::write(&destination, &file)?;
-            (destination, file.len())
-        }
-    };
-
-    let mut output_path = input_path.clone();
-    output_path.set_extension("ktx2");
-
-    // This file has already been hashed!
-    if output_path.exists() && USE_CACHE {
-        log::info!("Returning pre-compressed file!");
-    } else {
-        compress_image(&input_path, &mut output_path, texture_type)?;
-    }
-
-    // Now slurp up the image:
-    let file = fs_err::read(&output_path)?;
-    log::debug!("Tempfile is at {}", output_path.display());
-
-    Ok(file)
-}
-
 fn compress_image(
     input_path: &Path,
     output_path: &mut PathBuf,
+    texture_format: TextureFormat,
     texture_type: TextureType,
 ) -> anyhow::Result<()> {
     log::debug!("Deleting destination file if it exists");
@@ -365,16 +406,33 @@ fn compress_image(
         }
     }
 
-    toktx(input_path, output_path, texture_type)?;
+    toktx(input_path, output_path, texture_format, texture_type)?;
 
     Ok(())
 }
 
-fn toktx(input_path: &Path, output_path: &Path, texture_type: TextureType) -> anyhow::Result<()> {
+fn toktx(
+    input_path: &Path,
+    output_path: &Path,
+    format: TextureFormat,
+    texture_type: TextureType,
+) -> anyhow::Result<()> {
     let mut command = Command::new(BIN_TOKTX);
-    command.args(["--encode", "astc", "--astc_blk_d"]);
-    command.arg(texture_type.block_size());
-    command.args(["--astc_quality", "thorough", "--genmipmap"]);
+    command.args([
+        "--t2",        // Use KTX2 instead of KTX.
+        "--genmipmap", // Generate mipmaps.
+    ]);
+
+    match format {
+        TextureFormat::Rgba8 => {
+            command.args(["--target_type", "RGBA"]);
+        }
+        TextureFormat::Astc => {
+            command.args(["--encode", "astc", "--astc_blk_d"]);
+            command.arg(texture_type.block_size());
+            command.args(["--astc_quality", "thorough"]);
+        }
+    }
 
     if texture_type == TextureType::Normal {
         command.args(["--normal_mode", "--normalize"]);
@@ -406,8 +464,12 @@ fn toktx(input_path: &Path, output_path: &Path, texture_type: TextureType) -> an
 }
 
 // Create a temporary file. There's probably a better way to do this.
-fn file_name(file_bytes: &[u8]) -> PathBuf {
-    let hash = seahash::hash(file_bytes);
+fn file_name(format: TextureFormat, file_bytes: &[u8]) -> PathBuf {
+    let mut hasher = seahash::SeaHasher::new();
+    hasher.write_u8(format as _);
+    hasher.write(file_bytes);
+    let hash = hasher.finish();
+
     let mut path = std::env::temp_dir();
     path.set_file_name(format!("squisher_temp_{}", hash));
     path
@@ -441,25 +503,58 @@ fn open(path: &Path) -> anyhow::Result<Input> {
 mod tests {
     use super::*;
 
-    // pub fn test_that_it_works_with_gltf() {
-    //     // TODO - make sure that we delete the output file first.
-    //     squish("test_data/BoxTextured.gltf");
-    //     verify("test_data/BoxTextured_squished.glb");
-    // }
-
     #[test]
-    fn test_that_it_works_with_glb() {
-        squish(
-            "test_data/BoxTexturedBinary.glb",
-            "test_data/BoxTexturedBinary_squished.glb",
-        )
-        .unwrap();
-        verify("test_data/BoxTexturedBinary_squished.glb");
+    fn glb_astc() {
+        let args = Args {
+            input: "test_data/BoxTexturedBinary.glb".into(),
+            output: "test_output/BoxTexturedBinary_astc.glb".into(),
+            format: TextureFormat::Astc,
+            verbose: true,
+            no_cache: true,
+        };
+
+        let verification = VerifyArgs {
+            path: "test_output/BoxTexturedBinary_astc.glb",
+            format: ktx2::Format::ASTC_6x6_SRGB_BLOCK,
+            mip_level_count: 9,
+        };
+
+        fs_err::create_dir_all("test_output").unwrap();
+        squish(args).unwrap();
+        verify(verification);
     }
 
-    fn verify<P: AsRef<Path>>(p: P) {
-        let path = p.as_ref();
+    #[test]
+    fn glb_rgba8() {
+        let args = Args {
+            input: "test_data/BoxTexturedBinary.glb".into(),
+            output: "test_output/BoxTexturedBinary_raw.glb".into(),
+            format: TextureFormat::Rgba8,
+            verbose: true,
+            no_cache: true,
+        };
+
+        let verification = VerifyArgs {
+            path: "test_output/BoxTexturedBinary_raw.glb",
+            format: ktx2::Format::R8G8B8A8_SRGB,
+            mip_level_count: 9,
+        };
+
+        fs_err::create_dir_all("test_output").unwrap();
+        squish(args).unwrap();
+        verify(verification);
+    }
+
+    struct VerifyArgs {
+        path: &'static str,
+        format: ktx2::Format,
+        mip_level_count: u32,
+    }
+
+    fn verify(args: VerifyArgs) {
+        let path: &Path = args.path.as_ref();
         assert!(path.exists());
+
         let input = open(path).unwrap();
         for image in input.document.images() {
             match image.source() {
@@ -468,8 +563,9 @@ mod tests {
                     let bytes = &input.blob[view.offset()..view.offset() + view.length()];
                     let reader = ktx2::Reader::new(bytes).unwrap();
                     let header = reader.header();
-                    assert_eq!(header.format.unwrap(), ktx2::Format::ASTC_6x6_SRGB_BLOCK);
-                    assert_eq!(header.level_count, 9);
+
+                    assert_eq!(header.format, Some(args.format));
+                    assert_eq!(header.level_count, args.mip_level_count);
                 }
                 _ => unreachable!(),
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,7 +338,7 @@ fn compress_texture(
 }
 
 fn compress_image(
-    input_path: &PathBuf,
+    input_path: &Path,
     output_path: &mut PathBuf,
     texture_type: TextureType,
 ) -> anyhow::Result<()> {
@@ -368,7 +368,7 @@ fn compress_image(
 }
 
 #[allow(unused)]
-fn ktx2ktx2(output_path: &PathBuf) -> anyhow::Result<()> {
+fn ktx2ktx2(output_path: &Path) -> anyhow::Result<()> {
     // This command produces no output when it works correctly.
     let _output = Command::new(BIN_KTX2KTX2)
         .arg(output_path)
@@ -379,11 +379,7 @@ fn ktx2ktx2(output_path: &PathBuf) -> anyhow::Result<()> {
 }
 
 #[allow(unused)]
-fn astc(
-    input_path: &PathBuf,
-    output_path: &PathBuf,
-    texture_type: TextureType,
-) -> anyhow::Result<()> {
+fn astc(input_path: &Path, output_path: &Path, texture_type: TextureType) -> anyhow::Result<()> {
     // TODO: don't hardcode the path
     let mut astc_command = Command::new(BIN_ASTCENC);
 
@@ -424,11 +420,7 @@ fn astc(
     Ok(())
 }
 
-fn toktx(
-    input_path: &PathBuf,
-    output_path: &PathBuf,
-    texture_type: TextureType,
-) -> anyhow::Result<()> {
+fn toktx(input_path: &Path, output_path: &Path, texture_type: TextureType) -> anyhow::Result<()> {
     let mut command = Command::new(BIN_TOKTX);
     command.args(["--encode", "astc", "--astc_blk_d"]);
     command.arg(texture_type.block_size());

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,9 @@ use gltf::json::{image::MimeType, Index};
 
 const MAX_SIZE: u32 = 4096;
 
-#[allow(unused)]
-static ASTC_PATH: &str = r#"C:\Program Files\arm\astcenc-4.2.0-windows-x64\bin\astcenc-avx2.exe"#;
-#[allow(unused)]
-static KTX2KTX2_PATH: &str = r#"C:\Program Files\KTX-Software\bin\ktx2ktx2.exe"#;
-static TOKTX_PATH: &str = r#"C:\Program Files\KTX-Software\bin\toktx.exe"#;
+static BIN_ASTCENC: &str = "astcenc-avx2";
+static BIN_KTX2KTX2: &str = "ktx2ktx2";
+static BIN_TOKTX: &str = "toktx";
 
 /// Check for cached versions. Mark this as false if the compression algorithm changes in some way.
 const USE_CACHE: bool = true;
@@ -348,7 +346,7 @@ fn compress_image(input_path: &PathBuf, output_path: &mut PathBuf, texture_type:
 #[allow(unused)]
 fn ktx2ktx2(output_path: &PathBuf) {
     // This command produces no output when it works correctly.
-    let _output = Command::new(KTX2KTX2_PATH)
+    let _output = Command::new(BIN_KTX2KTX2)
         .arg(output_path)
         .output()
         .expect("Error calling ktx2ktx2");
@@ -357,7 +355,7 @@ fn ktx2ktx2(output_path: &PathBuf) {
 #[allow(unused)]
 fn astc(input_path: &PathBuf, output_path: &PathBuf, texture_type: TextureType) {
     // TODO: don't hardcode the path
-    let mut astc_command = Command::new(ASTC_PATH);
+    let mut astc_command = Command::new(BIN_ASTCENC);
 
     // Some textures need to be stored as linear data, some should be sRGB. atsc_enc lets us specify that.
     if texture_type.is_srgb() {
@@ -394,7 +392,7 @@ fn astc(input_path: &PathBuf, output_path: &PathBuf, texture_type: TextureType) 
 }
 
 fn toktx(input_path: &PathBuf, output_path: &PathBuf, texture_type: TextureType) {
-    let mut command = Command::new(TOKTX_PATH);
+    let mut command = Command::new(BIN_TOKTX);
     command.args(["--encode", "astc", "--astc_blk_d"]);
     command.arg(texture_type.block_size());
     command.args(["--astc_quality", "thorough", "--genmipmap"]);
@@ -490,7 +488,7 @@ mod tests {
                     let bytes = &input.blob[view.offset()..view.offset() + view.length()];
                     let reader = ktx2::Reader::new(bytes).unwrap();
                     let header = reader.header();
-                    assert_eq!(header.format.unwrap(), ktx2::Format::ASTC_8x8_SRGB_BLOCK);
+                    assert_eq!(header.format.unwrap(), ktx2::Format::ASTC_6x6_SRGB_BLOCK);
                     assert_eq!(header.level_count, 9);
                 }
                 _ => unreachable!(),


### PR DESCRIPTION
Part of #7. Closes #10.

This PR:
- Removes absolute paths in favor of relying on system PATH for executables
- Adds `clap` for argument parsing, now taking in an input and output parameter
- Adds `anyhow` and swaps out most of the panics in the projects with graceful error handling
- Adds `log` and `env_logger` for configurable logging that's a bit easier to parse
- Removes the non-toktx codepath for compressing textures.
- Adds an option for selecting which kind of texture compression to use: ASTC or RGBA8
- Refactors the core of the tool to enable more configuration options and easy tests
- A bit of miscellaneous clean up to the manifest file and test