### PR TITLE
First pass at CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - ci
 
   pull_request:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        include:
+          - label: Stable
+            rust_version: stable
+          - label: MSRV
+            rust_version: 1.67.1
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.label }} (${{ matrix.os }})
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust_version }}
+        override: true
+        profile: minimal
+
+    - name: Build
+      run: cargo build --verbose ${{ matrix.flags }}
+
+    # TODO: Get tests building 
+    # - name: Run tests
+    #   run: cargo test --verbose ${{ matrix.flags }}
+
+  lint:
+    name: Rustfmt and Clippy
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
+
+    - name: Rustfmt
+      run: cargo fmt -- --check
+
+    - name: Clippy
+      run: cargo clippy --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        include:
-          - label: Stable
-            rust_version: stable
-          - label: MSRV
-            rust_version: 1.67.1
+        rust_version: [stable, 1.67.1]
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.label }} (${{ matrix.os }})
+    name: ${{ matrix.os }} (${{ matrix.rust_version }})
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This PR introduces a basic GitHub Actions CI workflow to aid in ensuring the project stays functional. It ensures that the project builds on Windows and Linux, is formatted, and passes `cargo clippy`. It does not currently run the test suite, since that needs additional binaries.

Here is a run of the workflow on my fork: <https://github.com/LPGhatguy/squisher/actions/runs/4202264962>