### PR TITLE
Improve performance by reducing redundant work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,13 +449,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -458,7 +476,7 @@ dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -770,6 +788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,7 +824,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -880,6 +907,7 @@ dependencies = [
  "ktx2",
  "log",
  "seahash",
+ "tempfile",
 ]
 
 [[package]]
@@ -897,6 +925,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1036,6 +1077,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ gltf = { version = "1.0", features = ["KHR_lights_punctual"] }
 image = "0.24"
 log = "0.4.17"
 seahash = "4.1.0"
+tempfile = "3.4.0"
 
 [dev-dependencies]
 ktx2 = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,19 +210,19 @@ impl SquishContext {
             self.texture_format
         );
 
-        let (mut bytes, format, extension) = match texture.source().source() {
+        let (mut bytes, format) = match texture.source().source() {
             gltf::image::Source::View { view, mime_type } => {
                 let slice = &self.input.blob[view.offset()..view.offset() + view.length()];
                 let bytes = Cow::Borrowed(slice);
 
-                let (extension, format) = match mime_type {
-                    "image/jpeg" => ("jpg", image::ImageFormat::Jpeg),
-                    "image/png" => ("png", image::ImageFormat::Png),
+                let format = match mime_type {
+                    "image/jpeg" => image::ImageFormat::Jpeg,
+                    "image/png" => image::ImageFormat::Png,
                     "image/ktx2" => return Ok(None),
                     _ => bail!("unsupported image MIME Type {mime_type}"),
                 };
 
-                (bytes, format, extension)
+                (bytes, format)
             }
             gltf::image::Source::Uri { uri, .. } => {
                 log::warn!("Skipping texture at URI {uri}");
@@ -280,7 +280,6 @@ impl SquishContext {
         // Pipe the bytes through toktx, giving us spiffy KTX2 image bytes.
         let output = toktx(
             &bytes,
-            &output_path.with_extension(extension),
             self.texture_format,
             texture_type,
             self.use_supercompression,
@@ -431,7 +430,6 @@ fn pad_byte_vector(vec: &mut Vec<u8>) {
 
 fn toktx(
     input_bytes: &[u8],
-    _input_path: &Path,
     format: TextureFormat,
     texture_type: TextureType,
     supercompress: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -434,6 +434,8 @@ fn toktx(
     texture_type: TextureType,
     supercompress: bool,
 ) -> anyhow::Result<Vec<u8>> {
+    // Create a temporary file to put our image data into. Once `toktx` supports
+    // stdin inputs, we can remove this code.
     let dir = tempfile::tempdir()?;
     let input_path = dir.path().join("input");
     fs_err::write(&input_path, input_bytes).context("failed to write to temporary file")?;
@@ -513,7 +515,8 @@ fn cache_dir() -> PathBuf {
     path
 }
 
-// Create a temporary file. There's probably a better way to do this.
+// Generates a temporary file name suitable for writing a KTX2 file generated
+// from the given inputs.
 fn file_name(format: TextureFormat, supercompress: bool, file_bytes: &[u8]) -> PathBuf {
     let mut hasher = seahash::SeaHasher::new();
     hasher.write_u8(format as _);


### PR DESCRIPTION
Fixes #19.

This PR should improve `squisher`'s performance both when compressing images and when returning already-squished images.

This PR:
- Adopts `toktx`'s stdout output mode. This should help avoid a lot of I/O when squishing large images.
- Avoids writing input images to disk if they're already cached.
- Avoids decoding input images unless they need to be resized.
- Moves the temporary file writing code into the `toktx` function. This lets us skip that step if the image is already compressed. `compress_image` was removed in favor of using `tempfile` to manage the temporary input file.

Additionally, I've removed the URI image support temporarily as it appears that `squisher` does not currently resolve paths relative to the input file path. I'd like to reintroduce that in a follow-up PR and add a test case for it to ensure the paths are correct.

It turns out that `toktx` does not actually have an stdin input mode (https://github.com/KhronosGroup/KTX-Software/issues/637), so I wasn't able to make any changes on that front.